### PR TITLE
feat: Arreglo del bug de tamaño de la barra de navegación en modo responsive

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -93,11 +93,12 @@ function Navigation({ onGetLinks }: NavigationProps) {
                     </article>
                     {stateMenu ? (
                         <section>
+                    <hr className='p-0 mx-0 my-2 blurred'/>
                             {links.map(link => (
                                 <a
                                     key={link.src}
                                     href={link.src}
-                                    className={`flex items-center justify-center hover:transition hover:duration-300 hover:text-xl hover:bg-link-bg w-1/3
+                                    className={`flex items-center justify-center hover:transition hover:duration-300 hover:text-xl hover:bg-link-bg w-full
                                     ${selectRoute === link.src ? 'text-xl text-white bg-link-bg border-b-4 border-link-border' : 'text-sm'}`
                                     }
                                     onClick={() => setSelectRoute(link.src)}

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -1,0 +1,8 @@
+/* En tu archivo de estilos (navigation.css) */
+.blurred {
+    border: none;
+    height: 1px;
+    /* Altura del hr */
+    background-image: linear-gradient(to right, #855e6e, #ffdbd7 ,#b42529, #ffdbd7, #855e6e);
+    /* Degradado horizontal */
+}


### PR DESCRIPTION
Se arregla un problema con los estilos que causa que la barra de navegación no sea full y se añade un separador cuando se abre la barra de navegación en un móvil.